### PR TITLE
Clean up unused imports and sort order

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,7 +1,7 @@
 def build_agent(config, *args, **kwargs):
     algo_id = config.algo_id
     if algo_id == "ppo": 
-        from .ppo import PPOAgent               
+        from .ppo import PPOAgent
         return PPOAgent(config, *args, **kwargs)
     elif algo_id == "reinforce": 
         from .reinforce import REINFORCEAgent

--- a/agents/base_agent.py
+++ b/agents/base_agent.py
@@ -1,17 +1,19 @@
-import wandb
+from typing import Any, Dict, List
+
 import pytorch_lightning as pl
 import torch.nn as nn
-from typing import Dict, List, Any
-from utils.rollouts import RolloutCollector, RolloutTrajectory
+import wandb
+
+from utils.config import Config
 from utils.decorators import must_implement
 from utils.formatting import sanitize_name
 from utils.io import write_json
 from utils.metric_bundles import CoreMetricAlerts
 from utils.metrics_monitor import MetricsMonitor
 from utils.metrics_recorder import MetricsRecorder
+from utils.rollouts import RolloutCollector, RolloutTrajectory
 from utils.run import Run
 from utils.timings_tracker import TimingsTracker
-from utils.config import Config
 
 STAGES = ["train", "val", "test"]
 
@@ -367,9 +369,8 @@ class BaseAgent(pl.LightningModule):
     def _build_trainer_loggers__wandb(self):
         from dataclasses import asdict
 
-        from pytorch_lightning.loggers import WandbLogger
-
         import wandb
+        from pytorch_lightning.loggers import WandbLogger
 
         # Create the wandb logger, attach to the existing run if present
         project_name = self.config.project_id if self.config.project_id else sanitize_name(self.config.env_id)
@@ -430,15 +431,15 @@ class BaseAgent(pl.LightningModule):
         """Assemble trainer callbacks, with an optional end-of-training report."""
         # Lazy imports to avoid heavy deps at module import time
         from trainer_callbacks import (
+            ConsoleSummaryCallback,  # TODO; call this something else
             DispatchMetricsCallback,
             EarlyStoppingCallback,
-            ConsoleSummaryCallback, # TODO; call this something else
-            PrefitPresentationCallback,
+            HyperparameterScheduler,
             ModelCheckpointCallback,
             MonitorMetricsCallback,
+            PrefitPresentationCallback,
             WandbVideoLoggerCallback,
             WarmupEvalCallback,
-            HyperparameterScheduler,
         )
 
         # Initialize callbacks list

--- a/gym_wrappers/vec_video_recorder.py
+++ b/gym_wrappers/vec_video_recorder.py
@@ -1,7 +1,7 @@
 from contextlib import contextmanager
 from typing import Optional
 
-from gymnasium import Env, error
+from gymnasium import error
 from stable_baselines3.common.vec_env.base_vec_env import VecEnv, VecEnvWrapper
 
 from gym_wrappers.env_video_recorder import EnvVideoRecorder

--- a/loggers/metrics_table_logger.py
+++ b/loggers/metrics_table_logger.py
@@ -1,29 +1,32 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable, List, Optional, Tuple
-from dataclasses import dataclass
-
 import os
 import sys
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
-from pytorch_lightning.loggers.logger import Logger as LightningLoggerBase  # type: ignore
+from pytorch_lightning.loggers.logger import (
+    Logger as LightningLoggerBase,  # type: ignore
+)
 
+from utils.dict_utils import (
+    group_by_namespace as group_dict_by_key_namespace,
+)
+from utils.dict_utils import (
+    order_namespaces as order_grouped_namespaces,
+)
+from utils.dict_utils import (
+    sort_subkeys_by_priority as sort_grouped_subkeys_by_priority,
+)
+from utils.formatting import is_number, number_to_string
 from utils.logging import ansi as _ansi
 from utils.logging import apply_ansi_background as _apply_bg
 from utils.logging import strip_ansi_codes as _strip_ansi
-from utils.reports import sparkline as _sparkline
-from utils.dict_utils import (
-    group_by_namespace as group_dict_by_key_namespace,
-    order_namespaces as order_grouped_namespaces,
-    sort_subkeys_by_priority as sort_grouped_subkeys_by_priority,
-)
-from utils.torch import to_python_scalar as _to_python_scalar
 from utils.metrics_config import metrics_config
-from utils.formatting import (
-    is_number,
-    number_to_string
-)
 from utils.metrics_monitor import MetricsMonitor
+from utils.reports import sparkline as _sparkline
+from utils.torch import to_python_scalar as _to_python_scalar
+
 
 # TODO: REFACTOR this file
 @dataclass

--- a/scripts/benchmark_collectors.py
+++ b/scripts/benchmark_collectors.py
@@ -45,7 +45,7 @@ from utils.rollouts import RolloutCollector
 
 # SB3 imports (optional)
 try:
-    import torch.nn as nn  # noqa: F401
+    import torch.nn as nn
     from stable_baselines3 import PPO
     from stable_baselines3.common.callbacks import BaseCallback
     _HAS_SB3 = True

--- a/scripts/minari_bc_example.py
+++ b/scripts/minari_bc_example.py
@@ -95,7 +95,7 @@ def main() -> None:
     args = parse_args()
 
     try:
-        import minari  # noqa: F401
+        import minari
     except ImportError:
         print(
             "Minari is required. Install with: pip install \"minari[all]\"",
@@ -104,7 +104,6 @@ def main() -> None:
         raise
 
     import gymnasium as gym
-    import minari
 
     print(f"Loading Minari dataset: {args.dataset_id}")
     dataset = minari.load_dataset(args.dataset_id, download=True)

--- a/tests/test_ppo_kl_early_stop.py
+++ b/tests/test_ppo_kl_early_stop.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
 import torch
 import torch.nn as nn
-import pytest
 
 from agents.ppo.ppo_agent import PPOAgent
 from utils.config import PPOConfig

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,5 +1,5 @@
-from io import StringIO
 from contextlib import redirect_stdout
+from io import StringIO
 
 from utils.metrics_monitor import MetricAlert
 from utils.reports import print_terminal_ascii_alerts

--- a/train.py
+++ b/train.py
@@ -1,5 +1,7 @@
 import argparse
+
 from utils.train_launcher import launch_training_from_args
+
 
 def main():
     # Parse command line arguments

--- a/trainer_callbacks/__init__.py
+++ b/trainer_callbacks/__init__.py
@@ -1,14 +1,14 @@
 """Callbacks package for trainer callbacks."""
 
+from .console_summary import ConsoleSummaryCallback
 from .dispatch_metrics import DispatchMetricsCallback
 from .early_stopping import EarlyStoppingCallback
+from .hyperparameter_scheduler import HyperparameterScheduler
 from .model_checkpoint import ModelCheckpointCallback
 from .monitor_metrics import MonitorMetricsCallback
+from .prefit_presentation import PrefitPresentationCallback
 from .wandb_video_logger import WandbVideoLoggerCallback
 from .warmup_eval import WarmupEvalCallback
-from .console_summary import ConsoleSummaryCallback
-from .prefit_presentation import PrefitPresentationCallback
-from .hyperparameter_scheduler import HyperparameterScheduler
 
 __all__ = [
     "ModelCheckpointCallback", 

--- a/trainer_callbacks/console_summary.py
+++ b/trainer_callbacks/console_summary.py
@@ -8,7 +8,7 @@ than inside the agent.
 import pytorch_lightning as pl
 
 # TODO: move these to this file
-from utils.reports import print_terminal_ascii_summary, print_terminal_ascii_alerts
+from utils.reports import print_terminal_ascii_alerts, print_terminal_ascii_summary
 
 
 # TODO: call this callback something more appropriate

--- a/trainer_callbacks/model_checkpoint.py
+++ b/trainer_callbacks/model_checkpoint.py
@@ -7,10 +7,11 @@ from typing import Any
 import pytorch_lightning as pl
 import torch
 
-from utils.run import Run
 from utils.io import write_json
 from utils.metrics_serialization import prepare_metrics_for_json
+from utils.run import Run
 from utils.scalars import only_scalar_values
+
 
 class ModelCheckpointCallback(pl.Callback):
     """Custom checkpoint callback that handles all model checkpointing logic including resume."""

--- a/trainer_callbacks/monitor_metrics.py
+++ b/trainer_callbacks/monitor_metrics.py
@@ -4,6 +4,7 @@ from typing import List
 
 import pytorch_lightning as pl
 
+
 class MonitorMetricsCallback(pl.Callback):
 
     def on_train_epoch_end(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:

--- a/trainer_callbacks/prefit_presentation.py
+++ b/trainer_callbacks/prefit_presentation.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import pytorch_lightning as pl
 
-
 # TODO: REFACTOR this file
 
 # TODO: call this callback something else
@@ -22,6 +21,7 @@ class PrefitPresentationCallback(pl.Callback):
     def on_fit_start(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:  # type: ignore[override]
         # Lazy imports to keep module load light
         from dataclasses import asdict
+
         from utils.logging import display_config_summary
         from utils.torch import _device_of
         from utils.user import prompt_confirm

--- a/trainer_callbacks/wandb_video_logger.py
+++ b/trainer_callbacks/wandb_video_logger.py
@@ -7,10 +7,9 @@ from pathlib import Path
 from typing import Iterable
 
 import pytorch_lightning as pl
+import wandb
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
-
-import wandb
 
 
 @dataclass

--- a/utils/checkpoint.py
+++ b/utils/checkpoint.py
@@ -4,11 +4,11 @@ Set environment variable `VIBES_QUIET=1` (or `VIBES_DISABLE_CHECKPOINT_LOGS=1`)
 to suppress informational prints emitted during checkpoint loading.
 """
 
+import os
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import torch
-import os
 
 
 def _quiet_mode_enabled() -> bool:

--- a/utils/io.py
+++ b/utils/io.py
@@ -6,10 +6,10 @@ with explicit UTF-8 encoding across the codebase.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any, Union
 
-import json
 import yaml
 
 PathLike = Union[str, Path]

--- a/utils/metric_bundles.py
+++ b/utils/metric_bundles.py
@@ -1,7 +1,5 @@
-from typing import Callable, Iterable, List
-
-import math
 from statistics import fmean
+from typing import Callable, Iterable, List
 
 import pytorch_lightning as pl
 

--- a/utils/metrics_config.py
+++ b/utils/metrics_config.py
@@ -8,7 +8,7 @@ singleton so callers don't repeatedly read the file.
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional, List
+from typing import Any, Callable, Dict, List, Optional
 
 from utils.io import read_yaml
 

--- a/utils/metrics_history.py
+++ b/utils/metrics_history.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Mapping, Tuple
 
 from .metrics_config import metrics_config
 
+
 class MetricsHistory:
     """
     Lightweight numeric metrics history for terminal summaries.

--- a/utils/metrics_monitor.py
+++ b/utils/metrics_monitor.py
@@ -1,7 +1,8 @@
-from typing import Callable, Dict, List, Optional, Iterable, Tuple, Any, Union, Set
 from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 from .metrics_recorder import MetricsRecorder
+
 
 @dataclass(frozen=True)
 class MetricAlert:

--- a/utils/metrics_recorder.py
+++ b/utils/metrics_recorder.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Mapping, MutableMapping, List
-
 import math
+from typing import Any, Dict, List, Mapping, MutableMapping
 
 from .metrics_buffer import MetricsBuffer
 from .metrics_history import MetricsHistory

--- a/utils/metrics_serialization.py
+++ b/utils/metrics_serialization.py
@@ -6,14 +6,17 @@ to the configured key_priority across common namespaces.
 
 from __future__ import annotations
 
+import numbers
 from collections import OrderedDict
 from typing import Any, Dict, Iterable
 
-import numbers
-
 from utils.dict_utils import (
     group_by_namespace as _group_by_namespace,
+)
+from utils.dict_utils import (
     order_namespaces as _order_namespaces,
+)
+from utils.dict_utils import (
     sort_subkeys_by_priority as _sort_subkeys_by_priority,
 )
 from utils.metrics_config import metrics_config

--- a/utils/reports.py
+++ b/utils/reports.py
@@ -1,6 +1,7 @@
-from typing import Iterable, List, Dict, Any, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 from utils.logging import format_section_footer, format_section_header
+
 
 def downsample(seq: Iterable[float], target: int) -> List[float]:
     """Uniformly downsample a sequence to a target length (best-effort).

--- a/utils/run.py
+++ b/utils/run.py
@@ -15,9 +15,9 @@ import os
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
-from utils.config import Config
 from typing import Dict, List
 
+from utils.config import Config
 from utils.io import read_json
 
 LAST_RUN_DIR = Path("runs/@last") # TODO: use constant  

--- a/utils/train_launcher.py
+++ b/utils/train_launcher.py
@@ -35,6 +35,7 @@ def _init_wandb_sweep(config):
     """
     # Import locally to keep module import light for tests and non-W&B flows
     import wandb
+
     from utils.config import Config
 
     base = asdict(config)
@@ -108,6 +109,7 @@ def launch_training_from_args(args) -> None:
     post-training reporting.
     """
     from stable_baselines3.common.utils import set_random_seed
+
     from utils.config import load_config
     from utils.formatting import format_duration
     from utils.wandb_workspace import create_or_update_workspace_for_current_run

--- a/utils/wandb_workspace.py
+++ b/utils/wandb_workspace.py
@@ -219,7 +219,6 @@ def create_or_update_workspace(req: WorkspaceRequest) -> str:
 
     try:
         # Workspaces and panel primitives
-        import wandb_workspaces.reports.v2.interface as wr  # noqa: F401 - ensure importable
         from wandb_workspaces import workspaces as ws
     except Exception as e:
         raise ImportError("wandb-workspaces is required. pip install wandb-workspaces") from e


### PR DESCRIPTION
## Summary
- remove unused imports flagged by Ruff in wrappers, utilities, and metrics helpers
- normalize import grouping and ordering across modules via Ruff auto-fixes
- drop redundant unused-import suppressions in optional scripts and wandb workspace setup

## Testing
- `python -m ruff check --select F401,F403,F405`
- `python -m ruff check --select I`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68cd93adecf483328fffa1ddc6acc853